### PR TITLE
feat: add tag support to notes

### DIFF
--- a/web/src/pages/Home.tsx
+++ b/web/src/pages/Home.tsx
@@ -8,6 +8,7 @@ export default function Home() {
   const [rows, setRows] = useState<Row[]>([])
   const [title, setTitle] = useState('')
   const [content, setContent] = useState('')
+  const [tags, setTags] = useState('')
 
   async function load() {
     const { data } = await api.get<Row[]>('/pages')
@@ -16,8 +17,9 @@ export default function Home() {
   useEffect(() => { load() }, [])
 
   async function create() {
-    await api.post('/pages', { title, content })
-    setTitle(''); setContent('')
+    const tagList = tags.split(',').map(t => t.trim()).filter(Boolean)
+    await api.post('/pages', { title, content, tags: tagList })
+    setTitle(''); setContent(''); setTags('')
     load()
   }
 
@@ -26,6 +28,7 @@ export default function Home() {
       <div style={{display:'grid', gap:8, marginBottom:16}}>
         <input placeholder="Title" value={title} onChange={e=>setTitle(e.target.value)} />
         <textarea placeholder="Content (markdown ok)" rows={5} value={content} onChange={e=>setContent(e.target.value)}/>
+        <input placeholder="Tags (comma separated)" value={tags} onChange={e=>setTags(e.target.value)} />
         <button onClick={create}>Create Page</button>
       </div>
 

--- a/web/src/pages/PageView.tsx
+++ b/web/src/pages/PageView.tsx
@@ -26,6 +26,12 @@ export default function PageView() {
       <div>
         <input value={page.title} onChange={e=>save({ title: e.target.value })} style={{fontSize:18, width:'100%'}}/>
         <textarea value={page.content} onChange={e=>save({ content: e.target.value })} rows={20} style={{width:'100%', marginTop:8}}/>
+        <input
+          value={page.tags.join(', ')}
+          onChange={e=>save({ tags: e.target.value.split(',').map(t=>t.trim()).filter(Boolean) })}
+          placeholder="Tags (comma separated)"
+          style={{marginTop:8, width:'100%'}}
+        />
       </div>
       <AIPanel pageId={page.id} />
     </div>


### PR DESCRIPTION
## Summary
- add tags input when creating pages
- allow editing of tags on page view

## Testing
- `npm run build -w web`
- `npm run build -w api` *(fails: Could not find a declaration file for module 'pg')*

------
https://chatgpt.com/codex/tasks/task_e_6897a463be70832ab3ecfaa2a5e4763d