### PR TITLE
feat: add free tag suggestion

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -12,7 +12,8 @@
     "fastify": "^4.28.1",
     "node-fetch": "^3.3.2",
     "pg": "^8.11.5",
-    "zod": "^3.23.8"
+    "zod": "^3.23.8",
+    "keyword-extractor": "^0.0.28"
   },
   "devDependencies": {
     "tsx": "^4.15.7",

--- a/web/src/components/AIPanel.tsx
+++ b/web/src/components/AIPanel.tsx
@@ -5,6 +5,8 @@ export default function AIPanel({ pageId }: { pageId: string }) {
   const [related, setRelated] = useState<{id:string; title:string}[]>([])
   const [query, setQuery] = useState('')
   const [results, setResults] = useState<{id:string; title:string}[]>([])
+  const [suggested, setSuggested] = useState<string[]>([])
+  const [applying, setApplying] = useState(false)
 
   async function loadRelated() {
     const { data } = await api.post('/ai/related', { pageId, k:5 })
@@ -14,6 +16,24 @@ export default function AIPanel({ pageId }: { pageId: string }) {
   async function semanticSearch() {
     const { data } = await api.post('/ai/search', { query })
     setResults(data)
+  }
+
+  async function suggestTags() {
+    const { data } = await api.post('/ai/suggest-tags', { pageId })
+    setSuggested(data.tags || [])
+  }
+
+  async function applySuggested() {
+    if (!suggested.length) return
+    setApplying(true)
+    try {
+      const { data: page } = await api.get(`/pages/${pageId}`)
+      const current = Array.isArray(page.tags) ? page.tags : []
+      const next = Array.from(new Set([...(current as string[]), ...suggested]))
+      await api.put(`/pages/${pageId}`, { tags: next })
+    } finally {
+      setApplying(false)
+    }
   }
 
   return (
@@ -30,6 +50,20 @@ export default function AIPanel({ pageId }: { pageId: string }) {
         <ul>
           {results.map(r => <li key={r.id}>{r.title}</li>)}
         </ul>
+      </div>
+
+      <div style={{marginTop:16}}>
+        <button onClick={suggestTags}>Suggest Tags (free)</button>
+        {!!suggested.length && (
+          <>
+            <ul>
+              {suggested.map(t => <li key={t}>{t}</li>)}
+            </ul>
+            <button disabled={applying} onClick={applySuggested}>
+              {applying ? 'Applying…' : 'Apply Suggested Tags'}
+            </button>
+          </>
+        )}
       </div>
     </aside>
   )

--- a/web/src/pages/PageView.tsx
+++ b/web/src/pages/PageView.tsx
@@ -8,6 +8,7 @@ type Page = { id: string; title: string; content: string; tags: string[] }
 export default function PageView() {
   const { id } = useParams()
   const [page, setPage] = useState<Page | null>(null)
+  const [tagsText, setTagsText] = useState('')
 
   async function load() {
     const { data } = await api.get(`/pages/${id}`)
@@ -15,9 +16,29 @@ export default function PageView() {
   }
   useEffect(() => { load() }, [id])
 
+  useEffect(() => {
+    if (page?.tags) setTagsText(page.tags.join(', '))
+  }, [page])
+
   async function save(updates: Partial<Page>) {
     await api.put(`/pages/${id}`, updates)
     await load()
+  }
+
+  function parseTags(input: string): string[] {
+    return Array.from(
+      new Set(
+        input
+          .split(',')
+          .map(s => s.trim().toLowerCase())
+          .filter(Boolean)
+      )
+    )
+  }
+
+  async function saveTags(input: string) {
+    const tags = parseTags(input)
+    await save({ tags })
   }
 
   if (!page) return <div>Loading...</div>
@@ -25,15 +46,25 @@ export default function PageView() {
     <div style={{display:'grid', gridTemplateColumns:'1fr 320px', gap:16}}>
       <div>
         <input value={page.title} onChange={e=>save({ title: e.target.value })} style={{fontSize:18, width:'100%'}}/>
-        <textarea value={page.content} onChange={e=>save({ content: e.target.value })} rows={20} style={{width:'100%', marginTop:8}}/>
-        <input
-          value={page.tags.join(', ')}
-          onChange={e=>save({ tags: e.target.value.split(',').map(t=>t.trim()).filter(Boolean) })}
-          placeholder="Tags (comma separated)"
-          style={{marginTop:8, width:'100%'}}
+        <textarea
+          value={page.content}
+          onChange={e=>save({ content: e.target.value })}
+          rows={20}
+          style={{width:'100%', marginTop:8}}
         />
+        <div style={{marginTop:8}}>
+          <label style={{display:'block', fontWeight:600, marginBottom:4}}>Tags (comma-separated)</label>
+          <input
+            value={tagsText}
+            onChange={e => setTagsText(e.target.value)}
+            onBlur={e => saveTags(e.target.value)}
+            placeholder='ai, research, notes'
+            style={{width:'100%'}}
+          />
+        </div>
       </div>
       <AIPanel pageId={page.id} />
     </div>
   )
 }
+


### PR DESCRIPTION
## Summary
- suggest tags using local keyword extraction API
- surface suggested tags and apply action in AI panel
- expose manual tags input on page view

## Testing
- `pnpm -C api install` *(fails: GET https://registry.npmjs.org/keyword-extractor: Forbidden - 403)*
- `pnpm -C api build` *(fails: Cannot find module 'keyword-extractor')*
- `pnpm -C web build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6897a77d8de0832a82f8f05fa0057f03