### PR TITLE
feat: add cross page linking

### DIFF
--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -4,6 +4,7 @@ import cors from '@fastify/cors';
 import { registerPageRoutes } from './routes/pages.js';
 import { registerAIRoutes } from './routes/ai.js';
 import { registerAdminRoutes } from './routes/admin.js';
+import { registerLinkRoutes } from './routes/links.js';
 
 const app = Fastify({ logger: true });
 
@@ -14,6 +15,7 @@ app.get('/health', async () => ({ ok: true }));
 registerPageRoutes(app);
 registerAIRoutes(app);
 registerAdminRoutes(app);
+registerLinkRoutes(app);
 
 const port = Number(process.env.PORT || 3001);
 app.listen({ port, host: '0.0.0.0' })

--- a/api/src/routes/links.ts
+++ b/api/src/routes/links.ts
@@ -1,0 +1,30 @@
+import { FastifyInstance } from 'fastify';
+import { query } from '../db.js';
+
+export function registerLinkRoutes(app: FastifyInstance) {
+  // Outbound links
+  app.get('/pages/:id/links', async (req, reply) => {
+    const { id } = req.params as { id: string };
+    const { rows } = await query<{ id: string; title: string }>(`
+      select p.id, p.title
+      from page_link pl
+      join page p on p.id = pl.to_page_id
+      where pl.from_page_id = $1
+      order by p.title asc
+    `, [id]);
+    return rows;
+  });
+
+  // Backlinks (inbound)
+  app.get('/pages/:id/backlinks', async (req, reply) => {
+    const { id } = req.params as { id: string };
+    const { rows } = await query<{ id: string; title: string }>(`
+      select p.id, p.title
+      from page_link pl
+      join page p on p.id = pl.from_page_id
+      where pl.to_page_id = $1
+      order by p.title asc
+    `, [id]);
+    return rows;
+  });
+}

--- a/api/src/utils/links.ts
+++ b/api/src/utils/links.ts
@@ -1,0 +1,16 @@
+// Parse [[Page Title]] references and normalize titles
+export function extractWikiLinks(text: string): string[] {
+  if (!text) return [];
+  const re = /\[\[([^\]]+)\]\]/g;
+  const out: string[] = [];
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(text))) {
+    const t = m[1].trim();
+    if (t) out.push(t);
+  }
+  return out;
+}
+
+export function normTitle(s: string): string {
+  return s.trim().toLowerCase();
+}

--- a/infra/migrations/001_init.sql
+++ b/infra/migrations/001_init.sql
@@ -5,3 +5,15 @@ CREATE INDEX IF NOT EXISTS page_embedding_cos_idx
 ON page
 USING ivfflat (embedding vector_cosine_ops)
 WITH (lists = 100);
+
+-- Cross-page linking
+create table if not exists page_link (
+  from_page_id uuid references page(id) on delete cascade,
+  to_page_id   uuid references page(id) on delete cascade,
+  created_at   timestamptz default now(),
+  primary key (from_page_id, to_page_id)
+);
+
+-- Speed up lookups
+create index if not exists idx_page_link_from on page_link(from_page_id);
+create index if not exists idx_page_link_to   on page_link(to_page_id);

--- a/web/src/components/AIPanel.tsx
+++ b/web/src/components/AIPanel.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { api } from '../api'
 
 export default function AIPanel({ pageId }: { pageId: string }) {
@@ -7,6 +7,7 @@ export default function AIPanel({ pageId }: { pageId: string }) {
   const [results, setResults] = useState<{id:string; title:string}[]>([])
   const [suggested, setSuggested] = useState<string[]>([])
   const [applying, setApplying] = useState(false)
+  const [backlinks, setBacklinks] = useState<{id:string; title:string}[]>([])
 
   async function loadRelated() {
     const { data } = await api.post('/ai/related', { pageId, k:5 })
@@ -36,6 +37,12 @@ export default function AIPanel({ pageId }: { pageId: string }) {
     }
   }
 
+  async function loadBacklinks() {
+    const { data } = await api.get(`/pages/${pageId}/backlinks`)
+    setBacklinks(data)
+  }
+  useEffect(() => { loadBacklinks() }, [pageId])
+
   return (
     <aside style={{borderLeft:'1px solid #eee', paddingLeft:12}}>
       <h3>AI</h3>
@@ -64,6 +71,14 @@ export default function AIPanel({ pageId }: { pageId: string }) {
             </button>
           </>
         )}
+      </div>
+
+      <div style={{marginTop:16}}>
+        <h4>Backlinks</h4>
+        {!backlinks.length && <div style={{opacity:0.7}}>No backlinks yet</div>}
+        <ul>
+          {backlinks.map(b => <li key={b.id}><a href={`/page/${b.id}`}>{b.title}</a></li>)}
+        </ul>
       </div>
     </aside>
   )

--- a/web/src/pages/PageView.tsx
+++ b/web/src/pages/PageView.tsx
@@ -5,16 +5,48 @@ import AIPanel from '../components/AIPanel'
 
 type Page = { id: string; title: string; content: string; tags: string[] }
 
+function renderWikiLinks(text: string, resolver: (title: string) => string | undefined) {
+  const re = /\[\[([^\]]+)\]\]/g;
+  const parts: (string | JSX.Element)[] = [];
+  let lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(text))) {
+    const [full, title] = m;
+    const start = m.index;
+    if (start > lastIndex) parts.push(text.slice(lastIndex, start));
+    const href = resolver(title.trim());
+    parts.push(
+      href ? <a key={start} href={href}>{title}</a> : <span key={start}>[[{title}]]</span>
+    );
+    lastIndex = start + full.length;
+  }
+  if (lastIndex < text.length) parts.push(text.slice(lastIndex));
+  return parts;
+}
+
 export default function PageView() {
   const { id } = useParams()
   const [page, setPage] = useState<Page | null>(null)
   const [tagsText, setTagsText] = useState('')
+  const [links, setLinks] = useState<{id:string; title:string}[]>([])
 
   async function load() {
     const { data } = await api.get(`/pages/${id}`)
     setPage(data)
   }
   useEffect(() => { load() }, [id])
+
+  async function loadLinks() {
+    const { data } = await api.get(`/pages/${id}/links`)
+    setLinks(data)
+  }
+  useEffect(() => { if (id) loadLinks() }, [id])
+
+  function resolveHref(title: string) {
+    const t = title.trim().toLowerCase()
+    const match = links.find(l => l.title.trim().toLowerCase() === t)
+    return match ? `/page/${match.id}` : undefined
+  }
 
   useEffect(() => {
     if (page?.tags) setTagsText(page.tags.join(', '))
@@ -52,6 +84,10 @@ export default function PageView() {
           rows={20}
           style={{width:'100%', marginTop:8}}
         />
+        <div style={{marginTop:8, padding:8, background:'#fafafa', border:'1px solid #eee'}}>
+          <div style={{fontWeight:600, marginBottom:4}}>Preview with links</div>
+          <div>{renderWikiLinks(page.content, resolveHref)}</div>
+        </div>
         <div style={{marginTop:8}}>
           <label style={{display:'block', fontWeight:600, marginBottom:4}}>Tags (comma-separated)</label>
           <input


### PR DESCRIPTION
## Summary
- support [[Page Title]] wiki-link syntax with parser and link table
- expose REST endpoints for links and backlinks and render them in the UI

## Testing
- `DATABASE_URL=postgres://postgres:postgres@localhost:5433/notion_ai pnpm -C infra migrate` *(fails: connect ECONNREFUSED)*
- `pnpm -C api build` *(fails: Could not find a declaration file for module 'pg' and other missing types)*
- `pnpm -C web build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6897bd76515c832aaa049633c89d0834