### PR TITLE
feat(graph): add graph view and API

### DIFF
--- a/api/src/routes/links.ts
+++ b/api/src/routes/links.ts
@@ -27,4 +27,16 @@ export function registerLinkRoutes(app: FastifyInstance) {
     `, [id]);
     return rows;
   });
+
+  // Optional: graph data (nodes + edges)
+  app.get('/graph', async () => {
+    const pages = await query<{ id: string; title: string }>('select id, title from page', []);
+    const links = await query<{ from_page_id: string; to_page_id: string }>(
+      'select from_page_id, to_page_id from page_link', []
+    );
+    return {
+      nodes: pages.rows.map(p => ({ id: p.id, label: p.title })),
+      edges: links.rows.map(e => ({ from: e.from_page_id, to: e.to_page_id })),
+    };
+  });
 }

--- a/web/package.json
+++ b/web/package.json
@@ -13,7 +13,8 @@
     "dev": "^0.1.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-router-dom": "^6.23.1"
+    "react-router-dom": "^6.23.1",
+    "vis-network": "^9.1.9"
   },
   "devDependencies": {
     "@types/node": "^20.12.7",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -7,6 +7,7 @@ export default function App() {
         <h1 style={{fontSize:20}}>Notion AI Starter</h1>
         <nav style={{display:'flex', gap:12}}>
           <Link to="/">Table</Link>
+          <Link to="/graph">Graph</Link>
         </nav>
       </header>
       <Outlet/>

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -4,11 +4,13 @@ import { createBrowserRouter, RouterProvider } from 'react-router-dom'
 import App from './App'
 import Home from './pages/Home'
 import PageView from './pages/PageView'
+import Graph from './pages/Graph'
 
 const router = createBrowserRouter([
   { path: '/', element: <App />, children: [
     { index: true, element: <Home/> },
-    { path: 'page/:id', element: <PageView/> }
+    { path: 'page/:id', element: <PageView/> },
+    { path: 'graph', element: <Graph/> }
   ]}
 ])
 

--- a/web/src/pages/Graph.tsx
+++ b/web/src/pages/Graph.tsx
@@ -1,0 +1,28 @@
+import { useEffect, useRef } from 'react'
+import { api } from '../api'
+import { Network } from 'vis-network'
+
+export default function Graph() {
+  const el = useRef<HTMLDivElement | null>(null)
+
+  useEffect(() => {
+    let network: Network | null = null
+    async function load() {
+      const { data } = await api.get('/graph')
+      if (!el.current) return
+      network = new Network(el.current, data, {
+        nodes: { shape: 'dot', size: 12, font: { size: 14 } },
+        edges: { arrows: { to: { enabled: true, scaleFactor: 0.6 } }, color: '#bbb' },
+        physics: { stabilization: true }
+      })
+      network.on('doubleClick', (params: any) => {
+        const id = params?.nodes?.[0]
+        if (id) window.location.href = `/page/${id}`
+      })
+    }
+    load()
+    return () => { if (network) network.destroy() }
+  }, [])
+
+  return <div style={{ height: '70vh', border: '1px solid #eee', borderRadius: 6 }} ref={el} />
+}


### PR DESCRIPTION
## Summary
- expose graph data for pages via new `/graph` endpoint
- add graph visualization page using vis-network
- link graph view from app navigation and router

## Testing
- `pnpm -C web install` *(fails: GET https://registry.npmjs.org/vis-network: Forbidden - 403)*
- `pnpm -C web build` *(fails: vite: not found)*
- `pnpm -C api build` *(fails: Cannot find module 'crypto' or 'keyword-extractor')*
- `DATABASE_URL=postgres://postgres:postgres@localhost:5433/notion_ai pnpm -C infra migrate` *(fails: connect ECONNREFUSED 127.0.0.1:5433)*

------
https://chatgpt.com/codex/tasks/task_e_6897c46d5e10832aae24b0c7543dc5cf