### PR TITLE
feat: add hybrid search and spotlight

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -15,7 +15,8 @@
     "zod": "^3.23.8",
     "puppeteer": "^23.3.0",
     "katex": "^0.16.10",
-    "keyword-extractor": "^0.0.22"
+    "keyword-extractor": "^0.0.22",
+    "@xenova/transformers": "^3.0.0"
   },
   "devDependencies": {
     "tsx": "^4.15.7",

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -6,6 +6,7 @@ import { registerAIRoutes } from './routes/ai.js';
 import { registerAdminRoutes } from './routes/admin.js';
 import { registerLinkRoutes } from './routes/links.js';
 import { registerExportRoutes } from './routes/export.js';
+import { registerSearchRoutes } from './routes/search.js';
 
 const app = Fastify({ logger: true });
 
@@ -18,6 +19,7 @@ registerAIRoutes(app);
 registerAdminRoutes(app);
 registerLinkRoutes(app);
 registerExportRoutes(app);
+registerSearchRoutes(app);
 
 const port = Number(process.env.PORT || 3001);
 app.listen({ port, host: '0.0.0.0' })

--- a/api/src/llm.ts
+++ b/api/src/llm.ts
@@ -1,0 +1,34 @@
+import fetch from 'node-fetch'
+
+let pipelineCache: any = null
+
+export async function localGenerate(prompt: string): Promise<string | null> {
+  try {
+    const { pipeline } = await import('@xenova/transformers')
+    if (!pipelineCache) {
+      // small, CPU-friendly model; swap to a better one if your machine can handle it
+      pipelineCache = await pipeline('text-generation', 'Xenova/distilgpt2')
+    }
+    const out = await pipelineCache(prompt, { max_new_tokens: 220, temperature: 0.7, top_p: 0.9 })
+    const text = Array.isArray(out) ? out[0]?.generated_text || '' : String(out || '')
+    return text.slice(prompt.length).trim()
+  } catch (e) {
+    console.warn('localGenerate failed:', (e as Error).message)
+    return null
+  }
+}
+
+export async function openaiChat(system: string, user: string): Promise<string | null> {
+  const key = process.env.OPENAI_API_KEY
+  if (!key) return null
+  const r = await fetch('https://api.openai.com/v1/chat/completions', {
+    method: 'POST',
+    headers: { 'Authorization': `Bearer ${key}`, 'Content-Type':'application/json' },
+    body: JSON.stringify({ model: 'gpt-4o-mini', messages: [
+      { role:'system', content: system },
+      { role:'user', content: user }
+    ]})
+  })
+  const j: any = await r.json()
+  return j?.choices?.[0]?.message?.content ?? null
+}

--- a/api/src/routes/search.ts
+++ b/api/src/routes/search.ts
@@ -1,0 +1,98 @@
+import { FastifyInstance } from 'fastify'
+import { query as dbq } from '../db.js'
+import { embed } from '../embeddings.js'
+import { localGenerate, openaiChat } from '../llm.js'
+
+type PageLite = { id: string; title: string; snippet?: string }
+
+export function registerSearchRoutes(app: FastifyInstance) {
+  // Hybrid search: vector + keyword + optional tag filter
+  app.get('/search', async (req) => {
+    const { q = '', tags = '' } = (req.query as any) || {}
+    const tagsArr = String(tags).split(',').map((s)=>s.trim()).filter(Boolean)
+    const vec = q ? await embed(String(q)) : null
+
+    // keyword part
+    const kw = await dbq<PageLite>(`
+      SELECT p.id, p.title, left(p.content, 180) as snippet
+      FROM page p
+      LEFT JOIN page_tag pt ON pt.page_id = p.id
+      LEFT JOIN tag t ON t.id = pt.tag_id
+      WHERE ($1 = '' OR to_tsvector('english', p.title || ' ' || p.content) @@ plainto_tsquery('english', $1))
+        AND ($2::text[] IS NULL OR $2 = '{}'::text[] OR EXISTS (
+              SELECT 1 FROM page_tag pt2 JOIN tag t2 ON t2.id=pt2.tag_id
+              WHERE pt2.page_id=p.id AND t2.name = ANY($2)
+        ))
+      GROUP BY p.id
+      LIMIT 30
+    `, [q, tagsArr.length ? tagsArr : null])
+
+    // vector part
+    let sem: PageLite[] = []
+    if (vec) {
+      const r = await dbq<PageLite>(`
+        SELECT id, title, left(content, 180) as snippet
+        FROM page
+        ORDER BY embedding <=> $1
+        LIMIT 30
+      `, [vec])
+      sem = r.rows
+    }
+
+    // simple rank merge: keyword hits boosted; dedupe by id
+    const map = new Map<string, { rec: PageLite; score: number }>()
+    kw.rows.forEach((r, i)=> map.set(r.id, { rec: r, score: 1.0 + (30 - i)/100 }))
+    sem.forEach((r, i)=>{
+      const prev = map.get(r.id)
+      const s = 0.8 + (30 - i)/200
+      map.set(r.id, { rec: r, score: prev ? prev.score + s : s })
+    })
+
+    return Array.from(map.values())
+      .sort((a,b)=>b.score - a.score)
+      .slice(0, 20)
+      .map(x=>x.rec)
+  })
+
+  // Multi-doc synthesized answer with caching
+  app.post('/ai/answer', async (req) => {
+    const { query, k = 5 } = (req.body as any) || {}
+    if (!query || typeof query !== 'string') return { answer: '', sources: [] }
+
+    // cache hit?
+    const cached = await dbq<{ id: string; answer: string; sources: any }>(
+      'SELECT id, answer, sources FROM ai_answer_cache WHERE query=$1 ORDER BY created_at DESC LIMIT 1',
+      [query.trim()]
+    )
+    if (cached.rows.length) {
+      return { answer: cached.rows[0].answer, sources: cached.rows[0].sources }
+    }
+
+    const vec = await embed(query)
+    // fallback to keyword if no vec
+    const top = vec ? await dbq<{ id:string; title:string; content:string }>(`
+      SELECT id, title, content
+      FROM page
+      ORDER BY embedding <=> $1
+      LIMIT $2
+    `, [vec, Math.min(10, Number(k)||5)]) : await dbq(`
+      SELECT id, title, content FROM page
+      WHERE title ILIKE $1 OR content ILIKE $1
+      LIMIT $2
+    `, [`%${query}%`, Math.min(10, Number(k)||5)])
+
+    const docs = top.rows
+    if (!docs.length) return { answer: 'No relevant pages found.', sources: [] }
+
+    const context = docs.map((d, i)=>`[${i+1}] ${d.title}\n${d.content}\n`).join('\n---\n')
+    const sys = 'You are a helpful assistant. Read the provided notes and answer concisely in 4-6 sentences. Cite sources as [#] indices.'
+    const user = `Question: ${query}\n\nNotes:\n${context}\n\nAnswer:`
+
+    let answer = await localGenerate(`${sys}\n${user}`)
+    if (!answer) answer = (await openaiChat(sys, user)) || 'Unable to generate an answer at this time.'
+
+    const sources = docs.map((d)=>({ id: d.id, title: d.title }))
+    await dbq('INSERT INTO ai_answer_cache(query, answer, sources) VALUES ($1,$2,$3)', [query.trim(), answer, JSON.stringify(sources)])
+    return { answer, sources }
+  })
+}

--- a/infra/migrations/001_init.sql
+++ b/infra/migrations/001_init.sql
@@ -21,3 +21,13 @@ create index if not exists idx_page_link_to   on page_link(to_page_id);
 -- Page format: latex | rich
 ALTER TABLE page
 ADD COLUMN IF NOT EXISTS format text NOT NULL DEFAULT 'rich';
+
+-- Cache synthesized answers/summaries for search queries
+CREATE TABLE IF NOT EXISTS ai_answer_cache (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  query text NOT NULL,
+  answer text NOT NULL,
+  sources jsonb NOT NULL,     -- [{id,title},...]
+  created_at timestamptz DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS ai_answer_cache_query_idx ON ai_answer_cache USING gin (to_tsvector('english', query));

--- a/web/package.json
+++ b/web/package.json
@@ -26,7 +26,8 @@
     "@tabler/icons-react": "^2.47.0",
     "dayjs": "^1.11.12",
     "@tanstack/react-query": "^5.51.23",
-    "mantine-datatable": "^7.11.3"
+    "mantine-datatable": "^7.11.3",
+    "@mantine/spotlight": "^7.12.1"
   },
   "devDependencies": {
     "@types/node": "^20.12.7",

--- a/web/src/hooks/useSpotlightSearch.ts
+++ b/web/src/hooks/useSpotlightSearch.ts
@@ -1,0 +1,33 @@
+import { useEffect, useState } from 'react'
+import { api } from '../api'
+import { spotlight } from '@mantine/spotlight'
+
+export function useSpotlightSearch() {
+  const [query, setQuery] = useState('')
+  const [results, setResults] = useState<{id:string; title:string; snippet:string}[]>([])
+  const runSearch = async (q: string) => {
+    const params = new URLSearchParams({ q })
+    const { data } = await api.get(`/search?${params.toString()}`)
+    setResults(data)
+  }
+  useEffect(()=> {
+    const id = setTimeout(()=>{ if (query.trim()) runSearch(query) }, 200)
+    return ()=> clearTimeout(id)
+  }, [query])
+
+  useEffect(()=> {
+    spotlight.registerActions([
+      { id: 'new', label: 'New page', onClick: async ()=> { await api.post('/pages', { title: 'Untitled', content: '' }); window.location.reload() } },
+      { id: 'graph', label: 'Open graph', onClick: ()=> { window.location.href = '/graph' } },
+      ...results.map((r)=>({
+        id: r.id,
+        label: r.title,
+        description: r.snippet,
+        onClick: ()=> window.location.href = `/page/${r.id}`
+      }))
+    ])
+    return ()=> spotlight.clearActions()
+  }, [results])
+
+  return { query, setQuery, results }
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -5,6 +5,8 @@ import { MantineProvider } from '@mantine/core'
 import { Notifications } from '@mantine/notifications'
 import { ModalsProvider } from '@mantine/modals'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { Spotlight } from '@mantine/spotlight'
+import { useSpotlightSearch } from './hooks/useSpotlightSearch'
 import AppShellLayout from './shell/AppShellLayout'
 import Home from './pages/Home'
 import PageView from './pages/PageView'
@@ -21,8 +23,9 @@ const router = createBrowserRouter([
 
 const qc = new QueryClient()
 
-ReactDOM.createRoot(document.getElementById('root')!).render(
-  <React.StrictMode>
+function Root() {
+  const { setQuery } = useSpotlightSearch()
+  return (
     <QueryClientProvider client={qc}>
       <MantineProvider
         defaultColorScheme="auto"
@@ -35,9 +38,25 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
       >
         <Notifications position="top-right" />
         <ModalsProvider>
+          <Spotlight
+            actions={[]}
+            nothingFound="Type to search pages…"
+            highlightQuery
+            shortcut={['mod + K']}
+            limit={8}
+            searchProps={{ placeholder: 'Search or ask…' }}
+            filter={() => true}
+            onQueryChange={setQuery}
+          />
           <RouterProvider router={router} />
         </ModalsProvider>
       </MantineProvider>
     </QueryClientProvider>
+  )
+}
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <Root />
   </React.StrictMode>
 )

--- a/web/src/pages/Graph.tsx
+++ b/web/src/pages/Graph.tsx
@@ -1,12 +1,13 @@
-import { useEffect, useRef } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { api } from '../api'
 import { Network } from 'vis-network'
 import { Group, ActionIcon, Paper, Stack } from '@mantine/core'
-import { IconZoomIn, IconZoomOut, IconArrowsMaximize } from '@tabler/icons-react'
+import { IconZoomIn, IconZoomOut, IconArrowsMaximize, IconPlayerPlay, IconPlayerPause } from '@tabler/icons-react'
 
 export default function Graph() {
   const el = useRef<HTMLDivElement | null>(null)
   const networkRef = useRef<Network | null>(null)
+  const [physics, setPhysics] = useState(true)
 
   useEffect(() => {
     let network: Network | null = null
@@ -39,12 +40,23 @@ export default function Graph() {
     networkRef.current?.fit()
   }
 
+  function togglePhysics() {
+    const n = networkRef.current
+    if (!n) return
+    const next = !physics
+    n.setOptions({ physics: next })
+    setPhysics(next)
+  }
+
   return (
     <Stack>
       <Group gap="xs">
         <ActionIcon variant="light" onClick={() => zoom(1.2)}><IconZoomIn size={16} /></ActionIcon>
         <ActionIcon variant="light" onClick={() => zoom(0.8)}><IconZoomOut size={16} /></ActionIcon>
         <ActionIcon variant="light" onClick={fit}><IconArrowsMaximize size={16} /></ActionIcon>
+        <ActionIcon variant="light" onClick={togglePhysics}>
+          {physics ? <IconPlayerPause size={16} /> : <IconPlayerPlay size={16} />}
+        </ActionIcon>
       </Group>
       <Paper withBorder radius="md" style={{ height: '70vh' }}>
         <div ref={el} style={{ height: '100%' }} />

--- a/web/src/shell/HeaderBar.tsx
+++ b/web/src/shell/HeaderBar.tsx
@@ -1,6 +1,7 @@
 import { Group, ActionIcon, TextInput, Menu } from '@mantine/core'
 import { IconMenu2, IconLayoutSidebarRight, IconSearch, IconPlus, IconGraph, IconHome } from '@tabler/icons-react'
 import { useNavigate } from 'react-router-dom'
+import { spotlight } from '@mantine/spotlight'
 
 export default function HeaderBar({ onToggleNav, onToggleAside }:{ onToggleNav:()=>void; onToggleAside:()=>void }) {
   const nav = useNavigate()
@@ -17,9 +18,8 @@ export default function HeaderBar({ onToggleNav, onToggleAside }:{ onToggleNav:(
         w={480}
         onKeyDown={(e:any) => {
           if (e.key === 'Enter') {
-            const q = e.currentTarget.value
-            // navigate to home with ?q=...
-            nav(`/?q=${encodeURIComponent(q)}`)
+            spotlight.open()
+            spotlight.setQuery(e.currentTarget.value)
           }
         }}
       />

--- a/web/src/shell/RightAside.tsx
+++ b/web/src/shell/RightAside.tsx
@@ -1,4 +1,4 @@
-import { Tabs, ScrollArea, Stack, Button, List, Text, Group, Badge } from '@mantine/core'
+import { Tabs, ScrollArea, Stack, Button, List, Text, Group, Badge, Textarea } from '@mantine/core'
 import { useEffect, useState } from 'react'
 import { useLocation } from 'react-router-dom'
 import { api } from '../api'
@@ -10,8 +10,9 @@ export default function RightAside() {
 
   const [backlinks, setBacklinks] = useState<any[]>([])
   const [related, setRelated] = useState<any[]>([])
-  const [loadingAI, setLoadingAI] = useState(false)
-  const [summary, setSummary] = useState('')
+  const [ask, setAsk] = useState('')
+  const [answer, setAnswer] = useState('')
+  const [answering, setAnswering] = useState(false)
 
   useEffect(() => {
     if (!pageId) return
@@ -19,13 +20,12 @@ export default function RightAside() {
     api.post('/ai/related', { pageId, k: 5 }).then(({data})=>setRelated(data))
   }, [pageId])
 
-  async function summarize() {
-    if (!pageId) return
-    setLoadingAI(true)
+  async function askAI() {
+    setAnswering(true)
     try {
-      const { data } = await api.post('/ai/summarize', { pageId })
-      setSummary(data?.summary || '')
-    } finally { setLoadingAI(false) }
+      const { data } = await api.post('/ai/answer', { query: ask, k: 5 })
+      setAnswer(data?.answer || '')
+    } finally { setAnswering(false) }
   }
 
   return (
@@ -38,8 +38,9 @@ export default function RightAside() {
 
       <Tabs.Panel value="ai" p="md">
         <Stack gap="sm">
-          <Button loading={loadingAI} onClick={summarize}>Summarize</Button>
-          {summary && <Text size="sm">{summary}</Text>}
+          <Textarea value={ask} onChange={(e)=>setAsk(e.currentTarget.value)} placeholder="Ask across your pages…" autosize minRows={2}/>
+          <Button loading={answering} onClick={askAI}>Ask</Button>
+          {answer && <Text size="sm">{answer}</Text>}
         </Stack>
       </Tabs.Panel>
 


### PR DESCRIPTION
## Summary
- cache AI answers in new `ai_answer_cache` table
- support hybrid keyword/vector search and `/ai/answer` endpoint with local or OpenAI models
- integrate Spotlight search and ask panel in web UI with graph physics toggle

## Testing
- `pnpm -C api install` *(fails: GET https://registry.npmjs.org/@xenova%2Ftransformers: Forbidden - 403)*
- `pnpm -C web install` *(fails: GET https://registry.npmjs.org/@mantine%2Fspotlight: Forbidden - 403)*
- `pnpm -C api build` *(fails: TS2307 Cannot find module '@xenova/transformers')*
- `pnpm -C web build` *(fails: vite: not found)*
- `DATABASE_URL=postgres://postgres:postgres@localhost:5433/notion_ai pnpm -C infra migrate` *(fails: connect ECONNREFUSED 127.0.0.1:5433)*

------
https://chatgpt.com/codex/tasks/task_e_6897cfc261ac832a8737a5e1e07953d6