### PR TITLE
Allow creating pages with empty content

### DIFF
--- a/api/src/routes/pages.ts
+++ b/api/src/routes/pages.ts
@@ -8,7 +8,11 @@ import { snapshotPageVersion } from '../utils/history.js';
 
 const PageInput = z.object({
   title: z.string().min(1),
-  content: z.string().min(1),
+  // Allow creating pages with empty content so that clients can
+  // initialize a page before any text is added. Previously this schema
+  // required at least one character which caused a 400 error when the
+  // web app attempted to create an "Untitled" page with an empty body.
+  content: z.string(),
   tags: z.array(z.string()).optional(),
   format: z.enum(['latex', 'rich']).optional()
 });


### PR DESCRIPTION
## Summary
- permit creating new pages without initial content

## Testing
- `pnpm -C api build`
- `pnpm -C web build` (fails: vite: not found)
- `pnpm -C web install` (fails: inotify@1.4.6 build error)


------
https://chatgpt.com/codex/tasks/task_e_6897e00ad194832abe8941985f31909a