### PR TITLE
feat: add math support to editor

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,10 @@
     "concurrently": "^9.0.0"
   },
   "dependencies": {
+    "@tiptap/core": "^3.0.9",
+    "@tiptap/extension-mathematics": "^3.0.9",
     "clsx": "^2.1.1",
+    "katex": "^0.16.22",
     "lowlight": "^3.3.0",
     "mantine-datatable": "^8.2.0"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,18 @@ importers:
 
   .:
     dependencies:
+      '@tiptap/core':
+        specifier: ^3.0.9
+        version: 3.0.9(@tiptap/pm@3.0.9)
+      '@tiptap/extension-mathematics':
+        specifier: ^3.0.9
+        version: 3.0.9(@tiptap/core@3.0.9(@tiptap/pm@3.0.9))(@tiptap/pm@3.0.9)(katex@0.16.22)
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      katex:
+        specifier: ^0.16.22
+        version: 0.16.22
       lowlight:
         specifier: ^3.3.0
         version: 3.3.0
@@ -64,11 +73,38 @@ packages:
     peerDependencies:
       react: ^18.x || ^19.x
 
+  '@remirror/core-constants@3.0.0':
+    resolution: {integrity: sha512-42aWfPrimMfDKDi4YegyS7x+/0tlzaqwPQCULLanv3DMIlu96KTJR0fM5isWX2UViOqlGnX6YFgqWepcX+XMNg==}
+
+  '@tiptap/core@3.0.9':
+    resolution: {integrity: sha512-1zdDyILerBcD3P0fu8kCtPLOFj0R5utjexCQ2CZ46pckn/Wk4V+WUBARzhG5Yz2JDkmJIUIcmLBVrL6G1rjJWg==}
+    peerDependencies:
+      '@tiptap/pm': ^3.0.9
+
+  '@tiptap/extension-mathematics@3.0.9':
+    resolution: {integrity: sha512-8hfJU+9lo2nkYoEdn8fpvnis/i6KK9KwWStauyaUvUIxyX/JVv3YDJ7x222wWOdb0CK2uHaBtdKuRKinSBAICQ==}
+    peerDependencies:
+      '@tiptap/core': ^3.0.9
+      '@tiptap/pm': ^3.0.9
+      katex: ^0.16.4
+
+  '@tiptap/pm@3.0.9':
+    resolution: {integrity: sha512-cJdnpGyirRxwi6M4IkyapEK/jhcjFXdfX3uhJp/4uVH1dynNXalV0gE/YnH/yt55kzwvG9OUrwOQt+t1iXgNog==}
+
   '@types/diff-match-patch@1.0.36':
     resolution: {integrity: sha512-xFdR6tkm0MWvBfO8xXCSsinYxHcqkQUlcHeSpMC2ukzOb6lwQAfDmW+Qt0AvlGd8HpsS28qKsB+oPeJn9I39jg==}
 
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
+
+  '@types/linkify-it@5.0.0':
+    resolution: {integrity: sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==}
+
+  '@types/markdown-it@14.1.2':
+    resolution: {integrity: sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==}
+
+  '@types/mdurl@2.0.0':
+    resolution: {integrity: sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==}
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
@@ -80,6 +116,9 @@ packages:
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
+
+  argparse@2.0.1:
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -100,10 +139,17 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
+  commander@8.3.0:
+    resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
+    engines: {node: '>= 12'}
+
   concurrently@9.2.0:
     resolution: {integrity: sha512-IsB/fiXTupmagMW4MNp2lx2cdSN2FfZq78vF90LBB+zZHArbIQZjQtzXCiXnvTxCZSvXanTqFLWBjw2UkLx1SQ==}
     engines: {node: '>=18'}
     hasBin: true
+
+  crelt@1.0.6:
+    resolution: {integrity: sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==}
 
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
@@ -118,9 +164,17 @@ packages:
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
+  entities@4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
+
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
+
+  escape-string-regexp@4.0.0:
+    resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
+    engines: {node: '>=10'}
 
   get-caller-file@2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
@@ -142,6 +196,13 @@ packages:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
 
+  katex@0.16.22:
+    resolution: {integrity: sha512-XCHRdUw4lf3SKBaJe4EvgqIuWwkPSo9XoeO8GjQW94Bp7TWv9hNhzZjZ+OH9yf1UmLygb7DIT5GSFQiyt16zYg==}
+    hasBin: true
+
+  linkify-it@5.0.0:
+    resolution: {integrity: sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==}
+
   lodash@4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
 
@@ -156,6 +217,78 @@ packages:
       clsx: '>=2'
       react: '>=19'
       react-dom: '>=19'
+
+  markdown-it@14.1.0:
+    resolution: {integrity: sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==}
+    hasBin: true
+
+  mdurl@2.0.0:
+    resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
+
+  orderedmap@2.1.1:
+    resolution: {integrity: sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==}
+
+  prosemirror-changeset@2.3.1:
+    resolution: {integrity: sha512-j0kORIBm8ayJNl3zQvD1TTPHJX3g042et6y/KQhZhnPrruO8exkTgG8X+NRpj7kIyMMEx74Xb3DyMIBtO0IKkQ==}
+
+  prosemirror-collab@1.3.1:
+    resolution: {integrity: sha512-4SnynYR9TTYaQVXd/ieUvsVV4PDMBzrq2xPUWutHivDuOshZXqQ5rGbZM84HEaXKbLdItse7weMGOUdDVcLKEQ==}
+
+  prosemirror-commands@1.7.1:
+    resolution: {integrity: sha512-rT7qZnQtx5c0/y/KlYaGvtG411S97UaL6gdp6RIZ23DLHanMYLyfGBV5DtSnZdthQql7W+lEVbpSfwtO8T+L2w==}
+
+  prosemirror-dropcursor@1.8.2:
+    resolution: {integrity: sha512-CCk6Gyx9+Tt2sbYk5NK0nB1ukHi2ryaRgadV/LvyNuO3ena1payM2z6Cg0vO1ebK8cxbzo41ku2DE5Axj1Zuiw==}
+
+  prosemirror-gapcursor@1.3.2:
+    resolution: {integrity: sha512-wtjswVBd2vaQRrnYZaBCbyDqr232Ed4p2QPtRIUK5FuqHYKGWkEwl08oQM4Tw7DOR0FsasARV5uJFvMZWxdNxQ==}
+
+  prosemirror-history@1.4.1:
+    resolution: {integrity: sha512-2JZD8z2JviJrboD9cPuX/Sv/1ChFng+xh2tChQ2X4bB2HeK+rra/bmJ3xGntCcjhOqIzSDG6Id7e8RJ9QPXLEQ==}
+
+  prosemirror-inputrules@1.5.0:
+    resolution: {integrity: sha512-K0xJRCmt+uSw7xesnHmcn72yBGTbY45vm8gXI4LZXbx2Z0jwh5aF9xrGQgrVPu0WbyFVFF3E/o9VhJYz6SQWnA==}
+
+  prosemirror-keymap@1.2.3:
+    resolution: {integrity: sha512-4HucRlpiLd1IPQQXNqeo81BGtkY8Ai5smHhKW9jjPKRc2wQIxksg7Hl1tTI2IfT2B/LgX6bfYvXxEpJl7aKYKw==}
+
+  prosemirror-markdown@1.13.2:
+    resolution: {integrity: sha512-FPD9rHPdA9fqzNmIIDhhnYQ6WgNoSWX9StUZ8LEKapaXU9i6XgykaHKhp6XMyXlOWetmaFgGDS/nu/w9/vUc5g==}
+
+  prosemirror-menu@1.2.5:
+    resolution: {integrity: sha512-qwXzynnpBIeg1D7BAtjOusR+81xCp53j7iWu/IargiRZqRjGIlQuu1f3jFi+ehrHhWMLoyOQTSRx/IWZJqOYtQ==}
+
+  prosemirror-model@1.25.3:
+    resolution: {integrity: sha512-dY2HdaNXlARknJbrManZ1WyUtos+AP97AmvqdOQtWtrrC5g4mohVX5DTi9rXNFSk09eczLq9GuNTtq3EfMeMGA==}
+
+  prosemirror-schema-basic@1.2.4:
+    resolution: {integrity: sha512-ELxP4TlX3yr2v5rM7Sb70SqStq5NvI15c0j9j/gjsrO5vaw+fnnpovCLEGIcpeGfifkuqJwl4fon6b+KdrODYQ==}
+
+  prosemirror-schema-list@1.5.1:
+    resolution: {integrity: sha512-927lFx/uwyQaGwJxLWCZRkjXG0p48KpMj6ueoYiu4JX05GGuGcgzAy62dfiV8eFZftgyBUvLx76RsMe20fJl+Q==}
+
+  prosemirror-state@1.4.3:
+    resolution: {integrity: sha512-goFKORVbvPuAQaXhpbemJFRKJ2aixr+AZMGiquiqKxaucC6hlpHNZHWgz5R7dS4roHiwq9vDctE//CZ++o0W1Q==}
+
+  prosemirror-tables@1.7.1:
+    resolution: {integrity: sha512-eRQ97Bf+i9Eby99QbyAiyov43iOKgWa7QCGly+lrDt7efZ1v8NWolhXiB43hSDGIXT1UXgbs4KJN3a06FGpr1Q==}
+
+  prosemirror-trailing-node@3.0.0:
+    resolution: {integrity: sha512-xiun5/3q0w5eRnGYfNlW1uU9W6x5MoFKWwq/0TIRgt09lv7Hcser2QYV8t4muXbEr+Fwo0geYn79Xs4GKywrRQ==}
+    peerDependencies:
+      prosemirror-model: ^1.22.1
+      prosemirror-state: ^1.4.2
+      prosemirror-view: ^1.33.8
+
+  prosemirror-transform@1.10.4:
+    resolution: {integrity: sha512-pwDy22nAnGqNR1feOQKHxoFkkUtepoFAd3r2hbEDsnf4wp57kKA36hXsB3njA9FtONBEwSDnDeCiJe+ItD+ykw==}
+
+  prosemirror-view@1.40.1:
+    resolution: {integrity: sha512-pbwUjt3G7TlsQQHDiYSupWBhJswpLVB09xXm1YiJPdkjkh9Pe7Y51XdLh5VWIZmROLY8UpUpG03lkdhm9lzIBA==}
+
+  punycode.js@2.3.1:
+    resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
+    engines: {node: '>=6'}
 
   react-dom@19.1.1:
     resolution: {integrity: sha512-Dlq/5LAZgF0Gaz6yiqZCf6VCcZs1ghAJyrsu84Q/GT0gV+mCxbfmKNoGRKBYMJ8IEdGPqu49YWXD02GCknEDkw==}
@@ -212,6 +345,9 @@ packages:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
 
+  rope-sequence@1.3.4:
+    resolution: {integrity: sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==}
+
   rxjs@7.8.2:
     resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
 
@@ -251,6 +387,9 @@ packages:
   type-fest@4.41.0:
     resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
     engines: {node: '>=16'}
+
+  uc.micro@2.1.0:
+    resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
 
   use-callback-ref@1.3.3:
     resolution: {integrity: sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==}
@@ -298,6 +437,9 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  w3c-keyname@2.2.8:
+    resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==}
 
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
@@ -362,11 +504,53 @@ snapshots:
     dependencies:
       react: 19.1.1
 
+  '@remirror/core-constants@3.0.0': {}
+
+  '@tiptap/core@3.0.9(@tiptap/pm@3.0.9)':
+    dependencies:
+      '@tiptap/pm': 3.0.9
+
+  '@tiptap/extension-mathematics@3.0.9(@tiptap/core@3.0.9(@tiptap/pm@3.0.9))(@tiptap/pm@3.0.9)(katex@0.16.22)':
+    dependencies:
+      '@tiptap/core': 3.0.9(@tiptap/pm@3.0.9)
+      '@tiptap/pm': 3.0.9
+      katex: 0.16.22
+
+  '@tiptap/pm@3.0.9':
+    dependencies:
+      prosemirror-changeset: 2.3.1
+      prosemirror-collab: 1.3.1
+      prosemirror-commands: 1.7.1
+      prosemirror-dropcursor: 1.8.2
+      prosemirror-gapcursor: 1.3.2
+      prosemirror-history: 1.4.1
+      prosemirror-inputrules: 1.5.0
+      prosemirror-keymap: 1.2.3
+      prosemirror-markdown: 1.13.2
+      prosemirror-menu: 1.2.5
+      prosemirror-model: 1.25.3
+      prosemirror-schema-basic: 1.2.4
+      prosemirror-schema-list: 1.5.1
+      prosemirror-state: 1.4.3
+      prosemirror-tables: 1.7.1
+      prosemirror-trailing-node: 3.0.0(prosemirror-model@1.25.3)(prosemirror-state@1.4.3)(prosemirror-view@1.40.1)
+      prosemirror-transform: 1.10.4
+      prosemirror-view: 1.40.1
+
   '@types/diff-match-patch@1.0.36': {}
 
   '@types/hast@3.0.4':
     dependencies:
       '@types/unist': 3.0.3
+
+  '@types/linkify-it@5.0.0': {}
+
+  '@types/markdown-it@14.1.2':
+    dependencies:
+      '@types/linkify-it': 5.0.0
+      '@types/mdurl': 2.0.0
+
+  '@types/mdurl@2.0.0': {}
 
   '@types/unist@3.0.3': {}
 
@@ -375,6 +559,8 @@ snapshots:
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
+
+  argparse@2.0.1: {}
 
   chalk@4.1.2:
     dependencies:
@@ -395,6 +581,8 @@ snapshots:
 
   color-name@1.1.4: {}
 
+  commander@8.3.0: {}
+
   concurrently@9.2.0:
     dependencies:
       chalk: 4.1.2
@@ -404,6 +592,8 @@ snapshots:
       supports-color: 8.1.1
       tree-kill: 1.2.2
       yargs: 17.7.2
+
+  crelt@1.0.6: {}
 
   dequal@2.0.3: {}
 
@@ -415,7 +605,11 @@ snapshots:
 
   emoji-regex@8.0.0: {}
 
+  entities@4.5.0: {}
+
   escalade@3.2.0: {}
+
+  escape-string-regexp@4.0.0: {}
 
   get-caller-file@2.0.5: {}
 
@@ -426,6 +620,14 @@ snapshots:
   highlight.js@11.11.1: {}
 
   is-fullwidth-code-point@3.0.0: {}
+
+  katex@0.16.22:
+    dependencies:
+      commander: 8.3.0
+
+  linkify-it@5.0.0:
+    dependencies:
+      uc.micro: 2.1.0
 
   lodash@4.17.21: {}
 
@@ -442,6 +644,124 @@ snapshots:
       clsx: 2.1.1
       react: 19.1.1
       react-dom: 19.1.1(react@19.1.1)
+
+  markdown-it@14.1.0:
+    dependencies:
+      argparse: 2.0.1
+      entities: 4.5.0
+      linkify-it: 5.0.0
+      mdurl: 2.0.0
+      punycode.js: 2.3.1
+      uc.micro: 2.1.0
+
+  mdurl@2.0.0: {}
+
+  orderedmap@2.1.1: {}
+
+  prosemirror-changeset@2.3.1:
+    dependencies:
+      prosemirror-transform: 1.10.4
+
+  prosemirror-collab@1.3.1:
+    dependencies:
+      prosemirror-state: 1.4.3
+
+  prosemirror-commands@1.7.1:
+    dependencies:
+      prosemirror-model: 1.25.3
+      prosemirror-state: 1.4.3
+      prosemirror-transform: 1.10.4
+
+  prosemirror-dropcursor@1.8.2:
+    dependencies:
+      prosemirror-state: 1.4.3
+      prosemirror-transform: 1.10.4
+      prosemirror-view: 1.40.1
+
+  prosemirror-gapcursor@1.3.2:
+    dependencies:
+      prosemirror-keymap: 1.2.3
+      prosemirror-model: 1.25.3
+      prosemirror-state: 1.4.3
+      prosemirror-view: 1.40.1
+
+  prosemirror-history@1.4.1:
+    dependencies:
+      prosemirror-state: 1.4.3
+      prosemirror-transform: 1.10.4
+      prosemirror-view: 1.40.1
+      rope-sequence: 1.3.4
+
+  prosemirror-inputrules@1.5.0:
+    dependencies:
+      prosemirror-state: 1.4.3
+      prosemirror-transform: 1.10.4
+
+  prosemirror-keymap@1.2.3:
+    dependencies:
+      prosemirror-state: 1.4.3
+      w3c-keyname: 2.2.8
+
+  prosemirror-markdown@1.13.2:
+    dependencies:
+      '@types/markdown-it': 14.1.2
+      markdown-it: 14.1.0
+      prosemirror-model: 1.25.3
+
+  prosemirror-menu@1.2.5:
+    dependencies:
+      crelt: 1.0.6
+      prosemirror-commands: 1.7.1
+      prosemirror-history: 1.4.1
+      prosemirror-state: 1.4.3
+
+  prosemirror-model@1.25.3:
+    dependencies:
+      orderedmap: 2.1.1
+
+  prosemirror-schema-basic@1.2.4:
+    dependencies:
+      prosemirror-model: 1.25.3
+
+  prosemirror-schema-list@1.5.1:
+    dependencies:
+      prosemirror-model: 1.25.3
+      prosemirror-state: 1.4.3
+      prosemirror-transform: 1.10.4
+
+  prosemirror-state@1.4.3:
+    dependencies:
+      prosemirror-model: 1.25.3
+      prosemirror-transform: 1.10.4
+      prosemirror-view: 1.40.1
+
+  prosemirror-tables@1.7.1:
+    dependencies:
+      prosemirror-keymap: 1.2.3
+      prosemirror-model: 1.25.3
+      prosemirror-state: 1.4.3
+      prosemirror-transform: 1.10.4
+      prosemirror-view: 1.40.1
+
+  prosemirror-trailing-node@3.0.0(prosemirror-model@1.25.3)(prosemirror-state@1.4.3)(prosemirror-view@1.40.1):
+    dependencies:
+      '@remirror/core-constants': 3.0.0
+      escape-string-regexp: 4.0.0
+      prosemirror-model: 1.25.3
+      prosemirror-state: 1.4.3
+      prosemirror-view: 1.40.1
+
+  prosemirror-transform@1.10.4:
+    dependencies:
+      prosemirror-model: 1.25.3
+
+  prosemirror-view@1.40.1:
+    dependencies:
+      prosemirror-model: 1.25.3
+      prosemirror-state: 1.4.3
+      prosemirror-transform: 1.10.4
+
+  punycode.js@2.3.1: {}
 
   react-dom@19.1.1(react@19.1.1):
     dependencies:
@@ -487,6 +807,8 @@ snapshots:
 
   require-directory@2.1.1: {}
 
+  rope-sequence@1.3.4: {}
+
   rxjs@7.8.2:
     dependencies:
       tslib: 2.8.1
@@ -521,6 +843,8 @@ snapshots:
 
   type-fest@4.41.0: {}
 
+  uc.micro@2.1.0: {}
+
   use-callback-ref@1.3.3(react@19.1.1):
     dependencies:
       react: 19.1.1
@@ -544,6 +868,8 @@ snapshots:
       detect-node-es: 1.1.0
       react: 19.1.1
       tslib: 2.8.1
+
+  w3c-keyname@2.2.8: {}
 
   wrap-ansi@7.0.0:
     dependencies:

--- a/web/src/components/editor/EditorPro.tsx
+++ b/web/src/components/editor/EditorPro.tsx
@@ -17,12 +17,12 @@ import Toolbar from "./Toolbar";
 import Bubble from "./Bubble";
 import SlashMenu from "./SlashMenu";
 import Outline from "./Outline";
-import { MathInline, MathBlock, mathPMPlugin } from "./MathExtensions";
+import { MathInline, MathBlock } from "./MathExtensions";
 import "./styles.css";
 
 const lowlight = createLowlight(common);
 
-type Props = {  
+type Props = {
   value: string;
   onChange: (html: string) => void;
 };
@@ -70,9 +70,6 @@ export default function EditorPro({ value, onChange }: Props) {
         }
         return false;
       },
-    },
-    onCreate({ editor }) {
-      editor.registerPlugin(mathPMPlugin())
     },
     onUpdate: ({ editor }) => {
       onChange(editor.getHTML());

--- a/web/src/components/editor/EditorPro.tsx
+++ b/web/src/components/editor/EditorPro.tsx
@@ -17,6 +17,7 @@ import Toolbar from "./Toolbar";
 import Bubble from "./Bubble";
 import SlashMenu from "./SlashMenu";
 import Outline from "./Outline";
+import { MathInline, MathBlock, mathPMPlugin } from "./MathExtensions";
 import "./styles.css";
 
 const lowlight = createLowlight(common);
@@ -34,6 +35,8 @@ export default function EditorPro({ value, onChange }: Props) {
     extensions: [
       StarterKit.configure({ codeBlock: false }),
       CodeBlockLowlight.configure({ lowlight }),
+      MathInline,
+      MathBlock,
       Underline,
       Link.configure({
         protocols: ["http", "https", "mailto"],
@@ -67,6 +70,9 @@ export default function EditorPro({ value, onChange }: Props) {
         }
         return false;
       },
+    },
+    onCreate({ editor }) {
+      editor.registerPlugin(mathPMPlugin())
     },
     onUpdate: ({ editor }) => {
       onChange(editor.getHTML());

--- a/web/src/components/editor/MathExtensions.ts
+++ b/web/src/components/editor/MathExtensions.ts
@@ -1,0 +1,116 @@
+import { Node, mergeAttributes } from '@tiptap/core'
+import { mathPlugin, mathInline, mathDisplay, REGEX_INLINE, REGEX_BLOCK } from 'prosemirror-math'
+import katex from 'katex'
+
+// Inline math: $ ... $
+export const MathInline = Node.create({
+  name: 'math_inline',
+  group: 'inline',
+  atom: true,
+  inline: true,
+  selectable: true,
+  addAttributes() {
+    return { latex: { default: '' } }
+  },
+  parseHTML() {
+    return [
+      { tag: 'span.math-inline', getAttrs: el => ({ latex: (el as HTMLElement).getAttribute('data-latex') || '' }) },
+    ]
+  },
+  renderHTML({ HTMLAttributes }) {
+    const tex = HTMLAttributes.latex ?? ''
+    // store latex in attribute; TipTap will render the view with KaTeX
+    return ['span', mergeAttributes({ class: 'math-inline', 'data-latex': tex }), tex]
+  },
+  addNodeView() {
+    return ({ node }) => {
+      const dom = document.createElement('span')
+      dom.className = 'math-inline'
+      const tex: string = node.attrs.latex || ''
+      try {
+        dom.innerHTML = katex.renderToString(tex, { throwOnError: false })
+      } catch {
+        dom.textContent = `$${tex}$`
+      }
+      return { dom, update: (n) => {
+        if (n.type.name !== 'math_inline') return false
+        const t = n.attrs.latex || ''
+        try {
+          dom.innerHTML = katex.renderToString(t, { throwOnError: false })
+        } catch {
+          dom.textContent = `$${t}$`
+        }
+        return true
+      }}
+    }
+  },
+})
+
+// Block math: $$ ... $$
+export const MathBlock = Node.create({
+  name: 'math_display',
+  group: 'block',
+  atom: true,
+  code: false,
+  selectable: true,
+  defining: true,
+  addAttributes() {
+    return { latex: { default: '' } }
+  },
+  parseHTML() {
+    return [
+      { tag: 'div.math-display', getAttrs: el => ({ latex: (el as HTMLElement).getAttribute('data-latex') || '' }) },
+    ]
+  },
+  renderHTML({ HTMLAttributes }) {
+    const tex = HTMLAttributes.latex ?? ''
+    return ['div', mergeAttributes({ class: 'math-display', 'data-latex': tex }), tex]
+  },
+  addNodeView() {
+    return ({ node }) => {
+      const dom = document.createElement('div')
+      dom.className = 'math-display'
+      const tex: string = node.attrs.latex || ''
+      try {
+        dom.innerHTML = katex.renderToString(tex, { displayMode: true, throwOnError: false })
+      } catch {
+        dom.textContent = `$$${tex}$$`
+      }
+      return { dom, update: (n) => {
+        if (n.type.name !== 'math_display') return false
+        const t = n.attrs.latex || ''
+        try {
+          dom.innerHTML = katex.renderToString(t, { displayMode: true, throwOnError: false })
+        } catch {
+          dom.textContent = `$$${t}$$`
+        }
+        return true
+      }}
+    }
+  },
+})
+
+// ProseMirror plugin for input rules ($...$ / $$...$$)
+export function mathPMPlugin() {
+  return mathPlugin
+}
+
+// Helpers to insert/update math nodes from UI
+export function insertInlineMath(editor: any) {
+  const tex = prompt('Inline LaTeX (without $):') || ''
+  if (!tex) return
+  editor
+    .chain()
+    .focus()
+    .insertContent({ type: 'math_inline', attrs: { latex: tex } })
+    .run()
+}
+export function insertBlockMath(editor: any) {
+  const tex = prompt('Block LaTeX (without $$):') || ''
+  if (!tex) return
+  editor
+    .chain()
+    .focus()
+    .insertContent({ type: 'math_display', attrs: { latex: tex } })
+    .run()
+}

--- a/web/src/components/editor/SlashMenu.tsx
+++ b/web/src/components/editor/SlashMenu.tsx
@@ -1,5 +1,6 @@
 import { FloatingMenu, Editor } from '@tiptap/react'
 import { Card, Stack, Text } from '@mantine/core'
+import { insertInlineMath, insertBlockMath } from './MathExtensions'
 
 const items = [
   { key: 'h1', label:'Heading 1', run:(e:Editor)=>e.chain().focus().setHeading({level:1}).run() },
@@ -11,6 +12,8 @@ const items = [
   { key: 'code', label:'Code block', run:(e)=>e.chain().focus().toggleCodeBlock().run() },
   { key: 'table', label:'Table', run:(e)=>e.chain().focus().insertTable({rows:3, cols:3, withHeaderRow:true}).run() },
   { key: 'image', label:'Image', run:(e)=>{ const url=prompt('Image URL'); if(url) e.chain().focus().setImage({src:url}).run() } },
+  { key: 'math-inline', label:'Inline math ($…$)', run:(e)=>insertInlineMath(e) },
+  { key: 'math-block',  label:'Block math ($$…$$)', run:(e)=>insertBlockMath(e) },
 ]
 
 export default function SlashMenu({ editor }:{ editor: Editor }) {

--- a/web/src/components/editor/Toolbar.tsx
+++ b/web/src/components/editor/Toolbar.tsx
@@ -1,7 +1,8 @@
 import { ActionIcon, Group, Tooltip, SegmentedControl } from '@mantine/core'
-import { IconBold, IconItalic, IconUnderline, IconH1, IconH2, IconH3, IconList, IconListNumbers, IconCode, IconCodeCircle2, IconChecklist, IconLink, IconTable } from '@tabler/icons-react'
+import { IconBold, IconItalic, IconUnderline, IconH1, IconH2, IconH3, IconList, IconListNumbers, IconCode, IconCodeCircle2, IconChecklist, IconLink, IconTable, IconMathFunction, IconSquareFunction } from '@tabler/icons-react'
 import { Editor } from '@tiptap/react'
 import { toggleHeading, insertCodeBlock, insertTable, insertTodo } from './commands'
+import { insertInlineMath, insertBlockMath } from './MathExtensions'
 
 export default function Toolbar({ editor, onFullscreen, fullscreen }:{
   editor: Editor, onFullscreen: ()=>void, fullscreen: boolean
@@ -28,6 +29,8 @@ export default function Toolbar({ editor, onFullscreen, fullscreen }:{
       <Tooltip label="Task list"><ActionIcon onClick={()=>insertTodo(editor)} variant={editor.isActive('taskList')?'filled':'subtle'}><IconChecklist size={16}/></ActionIcon></Tooltip>
       <Tooltip label="Inline code"><ActionIcon onClick={()=>editor.chain().focus().toggleCode().run()} variant={editor.isActive('code')?'filled':'subtle'}><IconCode size={16}/></ActionIcon></Tooltip>
       <Tooltip label="Code block"><ActionIcon onClick={()=>insertCodeBlock(editor)} variant={editor.isActive('codeBlock')?'filled':'subtle'}><IconCodeCircle2 size={16}/></ActionIcon></Tooltip>
+      <Tooltip label="Inline math ($…$)"><ActionIcon onClick={()=>insertInlineMath(editor)}><IconMathFunction size={16}/></ActionIcon></Tooltip>
+      <Tooltip label="Block math ($$…$$)"><ActionIcon onClick={()=>insertBlockMath(editor)}><IconSquareFunction size={16}/></ActionIcon></Tooltip>
       <Tooltip label="Table"><ActionIcon onClick={()=>insertTable(editor)} variant={editor.isActive('table')?'filled':'subtle'}><IconTable size={16}/></ActionIcon></Tooltip>
       <Tooltip label="Link (⌘/Ctrl+K)"><ActionIcon onClick={()=>{
         const url = prompt('Enter URL'); if (!url) return

--- a/web/src/components/editor/Toolbar.tsx
+++ b/web/src/components/editor/Toolbar.tsx
@@ -1,43 +1,165 @@
-import { ActionIcon, Group, Tooltip, SegmentedControl } from '@mantine/core'
-import { IconBold, IconItalic, IconUnderline, IconH1, IconH2, IconH3, IconList, IconListNumbers, IconCode, IconCodeCircle2, IconChecklist, IconLink, IconTable, IconMathFunction, IconSquareFunction } from '@tabler/icons-react'
-import { Editor } from '@tiptap/react'
-import { toggleHeading, insertCodeBlock, insertTable, insertTodo } from './commands'
-import { insertInlineMath, insertBlockMath } from './MathExtensions'
+import { ActionIcon, Group, Tooltip, SegmentedControl } from "@mantine/core";
+import {
+  IconBold,
+  IconItalic,
+  IconUnderline,
+  IconH1,
+  IconH2,
+  IconH3,
+  IconList,
+  IconListNumbers,
+  IconCode,
+  IconCodeCircle2,
+  IconChecklist,
+  IconLink,
+  IconTable,
+  IconMathFunction,
+  IconSquare,
+} from "@tabler/icons-react";
+import { Editor } from "@tiptap/react";
+import {
+  toggleHeading,
+  insertCodeBlock,
+  insertTable,
+  insertTodo,
+} from "./commands";
+import { insertInlineMath, insertBlockMath } from "./MathExtensions";
 
-export default function Toolbar({ editor, onFullscreen, fullscreen }:{
-  editor: Editor, onFullscreen: ()=>void, fullscreen: boolean
+export default function Toolbar({
+  editor,
+  onFullscreen,
+  fullscreen,
+}: {
+  editor: Editor;
+  onFullscreen: () => void;
+  fullscreen: boolean;
 }) {
-  if (!editor) return null
+  if (!editor) return null;
 
   return (
-    <Group gap="xs" wrap="nowrap" style={{ position: 'sticky', top: 0, zIndex: 10, background: 'var(--mantine-color-body)', padding: 8, borderBottom: '1px solid var(--mantine-color-default-border)' }}>
-      <Tooltip label="Bold (⌘/Ctrl+B)"><ActionIcon onClick={()=>editor.chain().focus().toggleBold().run()} variant={editor.isActive('bold')?'filled':'subtle'}><IconBold size={16}/></ActionIcon></Tooltip>
-      <Tooltip label="Italic (⌘/Ctrl+I)"><ActionIcon onClick={()=>editor.chain().focus().toggleItalic().run()} variant={editor.isActive('italic')?'filled':'subtle'}><IconItalic size={16}/></ActionIcon></Tooltip>
-      <Tooltip label="Underline (⌘/Ctrl+U)"><ActionIcon onClick={()=>editor.chain().focus().toggleUnderline().run()} variant={editor.isActive('underline')?'filled':'subtle'}><IconUnderline size={16}/></ActionIcon></Tooltip>
+    <Group
+      gap="xs"
+      wrap="nowrap"
+      style={{
+        position: "sticky",
+        top: 0,
+        zIndex: 10,
+        background: "var(--mantine-color-body)",
+        padding: 8,
+        borderBottom: "1px solid var(--mantine-color-default-border)",
+      }}>
+      <Tooltip label="Bold (⌘/Ctrl+B)">
+        <ActionIcon
+          onClick={() => editor.chain().focus().toggleBold().run()}
+          variant={editor.isActive("bold") ? "filled" : "subtle"}>
+          <IconBold size={16} />
+        </ActionIcon>
+      </Tooltip>
+      <Tooltip label="Italic (⌘/Ctrl+I)">
+        <ActionIcon
+          onClick={() => editor.chain().focus().toggleItalic().run()}
+          variant={editor.isActive("italic") ? "filled" : "subtle"}>
+          <IconItalic size={16} />
+        </ActionIcon>
+      </Tooltip>
+      <Tooltip label="Underline (⌘/Ctrl+U)">
+        <ActionIcon
+          onClick={() => editor.chain().focus().toggleUnderline().run()}
+          variant={editor.isActive("underline") ? "filled" : "subtle"}>
+          <IconUnderline size={16} />
+        </ActionIcon>
+      </Tooltip>
       <SegmentedControl
         size="xs"
         data={[
-          { label: <IconH1 size={14}/>, value:'h1' },
-          { label: <IconH2 size={14}/>, value:'h2' },
-          { label: <IconH3 size={14}/>, value:'h3' },
+          { label: <IconH1 size={14} />, value: "h1" },
+          { label: <IconH2 size={14} />, value: "h2" },
+          { label: <IconH3 size={14} />, value: "h3" },
         ]}
-        value={['h1','h2','h3'].find(v => editor.isActive('heading', { level: Number(v[1]) })) || ''}
-        onChange={(v)=>toggleHeading(editor, Number(v[1]) as any)}
+        value={
+          ["h1", "h2", "h3"].find((v) =>
+            editor.isActive("heading", { level: Number(v[1]) })
+          ) || ""
+        }
+        onChange={(v) => toggleHeading(editor, Number(v[1]) as any)}
       />
-      <Tooltip label="Bullet list"><ActionIcon onClick={()=>editor.chain().focus().toggleBulletList().run()} variant={editor.isActive('bulletList')?'filled':'subtle'}><IconList size={16}/></ActionIcon></Tooltip>
-      <Tooltip label="Ordered list"><ActionIcon onClick={()=>editor.chain().focus().toggleOrderedList().run()} variant={editor.isActive('orderedList')?'filled':'subtle'}><IconListNumbers size={16}/></ActionIcon></Tooltip>
-      <Tooltip label="Task list"><ActionIcon onClick={()=>insertTodo(editor)} variant={editor.isActive('taskList')?'filled':'subtle'}><IconChecklist size={16}/></ActionIcon></Tooltip>
-      <Tooltip label="Inline code"><ActionIcon onClick={()=>editor.chain().focus().toggleCode().run()} variant={editor.isActive('code')?'filled':'subtle'}><IconCode size={16}/></ActionIcon></Tooltip>
-      <Tooltip label="Code block"><ActionIcon onClick={()=>insertCodeBlock(editor)} variant={editor.isActive('codeBlock')?'filled':'subtle'}><IconCodeCircle2 size={16}/></ActionIcon></Tooltip>
-      <Tooltip label="Inline math ($…$)"><ActionIcon onClick={()=>insertInlineMath(editor)}><IconMathFunction size={16}/></ActionIcon></Tooltip>
-      <Tooltip label="Block math ($$…$$)"><ActionIcon onClick={()=>insertBlockMath(editor)}><IconSquareFunction size={16}/></ActionIcon></Tooltip>
-      <Tooltip label="Table"><ActionIcon onClick={()=>insertTable(editor)} variant={editor.isActive('table')?'filled':'subtle'}><IconTable size={16}/></ActionIcon></Tooltip>
-      <Tooltip label="Link (⌘/Ctrl+K)"><ActionIcon onClick={()=>{
-        const url = prompt('Enter URL'); if (!url) return
-        editor.chain().focus().extendMarkRange('link').setLink({ href: url }).run()
-      }}><IconLink size={16}/></ActionIcon></Tooltip>
+      <Tooltip label="Bullet list">
+        <ActionIcon
+          onClick={() => editor.chain().focus().toggleBulletList().run()}
+          variant={editor.isActive("bulletList") ? "filled" : "subtle"}>
+          <IconList size={16} />
+        </ActionIcon>
+      </Tooltip>
+      <Tooltip label="Ordered list">
+        <ActionIcon
+          onClick={() => editor.chain().focus().toggleOrderedList().run()}
+          variant={editor.isActive("orderedList") ? "filled" : "subtle"}>
+          <IconListNumbers size={16} />
+        </ActionIcon>
+      </Tooltip>
+      <Tooltip label="Task list">
+        <ActionIcon
+          onClick={() => insertTodo(editor)}
+          variant={editor.isActive("taskList") ? "filled" : "subtle"}>
+          <IconChecklist size={16} />
+        </ActionIcon>
+      </Tooltip>
+      <Tooltip label="Inline code">
+        <ActionIcon
+          onClick={() => editor.chain().focus().toggleCode().run()}
+          variant={editor.isActive("code") ? "filled" : "subtle"}>
+          <IconCode size={16} />
+        </ActionIcon>
+      </Tooltip>
+      <Tooltip label="Code block">
+        <ActionIcon
+          onClick={() => insertCodeBlock(editor)}
+          variant={editor.isActive("codeBlock") ? "filled" : "subtle"}>
+          <IconCodeCircle2 size={16} />
+        </ActionIcon>
+      </Tooltip>
+      <Tooltip label="Inline math ($…$)">
+        <ActionIcon onClick={() => insertInlineMath(editor)}>
+          <IconMathFunction size={16} />
+        </ActionIcon>
+      </Tooltip>
+      <Tooltip label="Block math ($$…$$)">
+        <ActionIcon onClick={() => insertBlockMath(editor)}>
+          <IconSquare size={16} />
+        </ActionIcon>
+      </Tooltip>
+      <Tooltip label="Table">
+        <ActionIcon
+          onClick={() => insertTable(editor)}
+          variant={editor.isActive("table") ? "filled" : "subtle"}>
+          <IconTable size={16} />
+        </ActionIcon>
+      </Tooltip>
+      <Tooltip label="Link (⌘/Ctrl+K)">
+        <ActionIcon
+          onClick={() => {
+            const url = prompt("Enter URL");
+            if (!url) return;
+            editor
+              .chain()
+              .focus()
+              .extendMarkRange("link")
+              .setLink({ href: url })
+              .run();
+          }}>
+          <IconLink size={16} />
+        </ActionIcon>
+      </Tooltip>
       <div style={{ flex: 1 }} />
-      <SegmentedControl size="xs" data={[{label:'Normal',value:'n'},{label:'Full',value:'f'}]} value={fullscreen?'f':'n'} onChange={()=>onFullscreen()} />
+      <SegmentedControl
+        size="xs"
+        data={[
+          { label: "Normal", value: "n" },
+          { label: "Full", value: "f" },
+        ]}
+        value={fullscreen ? "f" : "n"}
+        onChange={() => onFullscreen()}
+      />
     </Group>
-  )
+  );
 }

--- a/web/src/components/editor/styles.css
+++ b/web/src/components/editor/styles.css
@@ -8,3 +8,6 @@
 .tiptap pre { background: var(--mantine-color-dark-6); color: #eaeef1; padding: 12px; border-radius: 8px; overflow: auto; }
 .tiptap code { background: var(--mantine-color-default); padding: 0 4px; border-radius: 4px; }
 .tiptap img { max-width: 100%; border-radius: 8px; }
+.tiptap .math-inline { padding: 0 2px; }
+.tiptap .math-display { margin: 12px 0; }
+.tiptap .katex-display { overflow-x: auto; }


### PR DESCRIPTION
## Summary
- add TipTap math extensions wrapping prosemirror-math and KaTeX rendering
- enable math in EditorPro with plugin registration
- expose inline and block math actions in toolbar and slash menu

## Testing
- `pnpm build` *(fails: sh: 1: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6897e9d4da1c832a8b80e022584319c4