### PR TITLE
feat: add modal-based math input

### DIFF
--- a/web/src/components/editor/MathExtensions.ts
+++ b/web/src/components/editor/MathExtensions.ts
@@ -1,6 +1,8 @@
 import { Node, mergeAttributes } from "@tiptap/core";
+import { Editor } from "@tiptap/react";
 import Mathematics from "@tiptap/extension-mathematics";
 import katex from "katex";
+import { openMathModal } from "./MathModal";
 
 // Use the official TipTap math extension
 export const MathExtension = Mathematics.configure({
@@ -162,30 +164,56 @@ export const MathBlock = Node.create({
 });
 
 // Helper functions
-export function insertInlineMath(editor: any) {
-  const latex = prompt("Enter LaTeX formula:") || "";
-  if (!latex) return;
+export function insertInlineMath(editor: Editor) {
+  const isEditing = editor.isActive("math_inline");
+  const initialLatex = isEditing
+    ? (editor.getAttributes("math_inline").latex as string) || ""
+    : "";
 
-  editor
-    .chain()
-    .focus()
-    .insertContent({
-      type: "math_inline",
-      attrs: { latex },
-    })
-    .run();
+  openMathModal({
+    initialValue: initialLatex,
+    displayMode: false,
+    submitLabel: isEditing ? "Update" : "Insert",
+    title: isEditing ? "Edit inline math" : "Insert inline math",
+    onSubmit: (latex) => {
+      const chain = editor.chain().focus();
+      if (isEditing) {
+        chain.updateAttributes("math_inline", { latex }).run();
+      } else {
+        chain
+          .insertContent({
+            type: "math_inline",
+            attrs: { latex },
+          })
+          .run();
+      }
+    },
+  });
 }
 
-export function insertBlockMath(editor: any) {
-  const latex = prompt("Enter LaTeX formula:") || "";
-  if (!latex) return;
+export function insertBlockMath(editor: Editor) {
+  const isEditing = editor.isActive("math_display");
+  const initialLatex = isEditing
+    ? (editor.getAttributes("math_display").latex as string) || ""
+    : "";
 
-  editor
-    .chain()
-    .focus()
-    .insertContent({
-      type: "math_display",
-      attrs: { latex },
-    })
-    .run();
+  openMathModal({
+    initialValue: initialLatex,
+    displayMode: true,
+    submitLabel: isEditing ? "Update" : "Insert",
+    title: isEditing ? "Edit block math" : "Insert block math",
+    onSubmit: (latex) => {
+      const chain = editor.chain().focus();
+      if (isEditing) {
+        chain.updateAttributes("math_display", { latex }).run();
+      } else {
+        chain
+          .insertContent({
+            type: "math_display",
+            attrs: { latex },
+          })
+          .run();
+      }
+    },
+  });
 }

--- a/web/src/components/editor/MathModal.tsx
+++ b/web/src/components/editor/MathModal.tsx
@@ -1,0 +1,135 @@
+import { useMemo, useState } from "react";
+import { modals } from "@mantine/modals";
+import { Button, Group, Paper, Stack, Text, Textarea } from "@mantine/core";
+import katex from "katex";
+
+type MathModalOptions = {
+  initialValue?: string;
+  displayMode: boolean;
+  onSubmit: (latex: string) => void;
+  title?: string;
+  submitLabel?: string;
+};
+
+type MathModalContentProps = {
+  initialValue: string;
+  displayMode: boolean;
+  submitLabel: string;
+  onSubmit: (latex: string) => void;
+  onCancel: () => void;
+};
+
+function MathModalContent({
+  initialValue,
+  displayMode,
+  submitLabel,
+  onSubmit,
+  onCancel,
+}: MathModalContentProps) {
+  const [value, setValue] = useState(initialValue);
+
+  const { html, error } = useMemo(() => {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return { html: "", error: "" };
+    }
+
+    try {
+      return {
+        html: katex.renderToString(trimmed, {
+          displayMode,
+          throwOnError: false,
+        }),
+        error: "",
+      };
+    } catch (err) {
+      return { html: "", error: (err as Error).message };
+    }
+  }, [value, displayMode]);
+
+  return (
+    <Stack gap="md">
+      <div>
+        <Text size="sm" fw={500} mb={4}>
+          LaTeX expression
+        </Text>
+        <Textarea
+          value={value}
+          onChange={(event) => setValue(event.currentTarget.value)}
+          minRows={5}
+          autosize
+          data-autofocus
+          placeholder={displayMode ? "\\int_a^b f(x) dx" : "E = mc^2"}
+          styles={{ textarea: { fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace" } }}
+        />
+      </div>
+      <div>
+        <Text size="sm" fw={500} mb={4}>
+          Preview
+        </Text>
+        <Paper
+          withBorder
+          radius="md"
+          p="md"
+          style={{ minHeight: 80, display: "flex", alignItems: "center", justifyContent: "center" }}
+        >
+          {error ? (
+            <Text size="sm" c="red">
+              {error}
+            </Text>
+          ) : html ? (
+            <div dangerouslySetInnerHTML={{ __html: html }} />
+          ) : (
+            <Text size="sm" c="dimmed">
+              Start typing to see a preview.
+            </Text>
+          )}
+        </Paper>
+      </div>
+      <Group justify="flex-end">
+        <Button variant="subtle" onClick={onCancel}>
+          Cancel
+        </Button>
+        <Button
+          onClick={() => {
+            onSubmit(value.trim());
+          }}
+          disabled={!value.trim()}
+        >
+          {submitLabel}
+        </Button>
+      </Group>
+    </Stack>
+  );
+}
+
+export function openMathModal({
+  initialValue = "",
+  displayMode,
+  onSubmit,
+  title,
+  submitLabel = "Insert",
+}: MathModalOptions) {
+  const id = modals.open({
+    title: title ?? (displayMode ? "Insert block math" : "Insert inline math"),
+    children: (
+      <MathModalContent
+        initialValue={initialValue}
+        displayMode={displayMode}
+        submitLabel={submitLabel}
+        onSubmit={(latex) => {
+          onSubmit(latex);
+          modals.close(id);
+        }}
+        onCancel={() => modals.close(id)}
+      />
+    ),
+    centered: true,
+    size: "lg",
+    withinPortal: true,
+  });
+
+  return id;
+}
+
+export default openMathModal;


### PR DESCRIPTION
## Summary
- add a reusable modal with live KaTeX preview for math entry
- replace prompt-based math insertion commands with the new modal for inline and block equations

## Testing
- pnpm build *(fails: vite not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc2dc687b0832a84077c60f1b55965